### PR TITLE
Fix memory leak and address errors/warnings with GCC

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <iomanip>
 #include <string.h>
+#include <cstdint>
 
 #include "sha256.h"
 #include "miner.h"

--- a/miner.cpp
+++ b/miner.cpp
@@ -1,4 +1,4 @@
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <chrono>
 
@@ -64,7 +64,7 @@ uint32_t mineblock(uint32_t noncestart, char* version, char* prevhash,
     hexstr_to_intarray(nbits, bits);
     bits_to_difficulty(*bits, difficulty);
 
-    char solved = 0;
+    /* char solved = 0; */
     uint32_t hash[8];
     uint32_t nonce = noncestart-1;
 
@@ -80,7 +80,7 @@ uint32_t mineblock(uint32_t noncestart, char* version, char* prevhash,
         {
             if(hash[7-i] < difficulty[i])
             {
-                solved = 1;
+                /* solved = 1; */
                 return nonce;
             }
             else if(hash[7-i] > difficulty[i])

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <iostream>
 
 uint32_t rotateInt(uint32_t inputWord, int numberOfBitsToRotate) 
@@ -70,7 +71,7 @@ void hash(uint32_t *input, int bitlength, uint32_t *outputlocation)
     0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
 
     int wordlength = bitlength / 32 + 1;
-    int k = (512 * 512 - bitlength - 1) % 512;
+    /* int k = (512 * 512 - bitlength - 1) % 512; */
     uint32_t message[10000] = {};
 
     for(int i = 0; i < wordlength; i++)
@@ -97,8 +98,8 @@ void hash(uint32_t *input, int bitlength, uint32_t *outputlocation)
         
     uint32_t M[32][16];
 
-    for(int i = 0; i < 16; i++)
-        for(int j = 0; j <= rounds; j++)
+    for(uint32_t i = 0; i < 16; i++)
+        for(uint32_t j = 0; j <= rounds; j++)
             M[j][i] = message[i + j * 16];
     
     uint32_t H[32][8];
@@ -107,7 +108,7 @@ void hash(uint32_t *input, int bitlength, uint32_t *outputlocation)
         H[0][i] = H_0[i];
 
     // Here our hash function rounds actually start.
-    for(int i = 1; i <= rounds; i++)
+    for(uint32_t i = 1; i <= rounds; i++)
     {
         uint32_t a = H[i-1][0];
         uint32_t b = H[i-1][1];

--- a/util.cpp
+++ b/util.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <string.h>
@@ -49,7 +50,7 @@ void hexstr_to_intarray(const char* hexstr, uint32_t* outputloc)
 
     for(size_t i = 0; i < intlen; i++)
     {
-        uint32_t a = (uint32_t)bytes[i * 4 + 3] << 24;
+        /* uint32_t a = (uint32_t)bytes[i * 4 + 3] << 24; */
         *(outputloc + i) = ((uint32_t)bytes[i * 4])
             + ((uint32_t)bytes[i * 4 + 1] << 8)
             + ((uint32_t)bytes[i * 4 + 2] << 16)

--- a/util.cpp
+++ b/util.cpp
@@ -55,4 +55,5 @@ void hexstr_to_intarray(const char* hexstr, uint32_t* outputloc)
             + ((uint32_t)bytes[i * 4 + 2] << 16)
             + ((uint32_t)bytes[i * 4 + 3] << 24);
     }
+    free(bytes);
 }


### PR DESCRIPTION
When compiling with GCC, a lot of errors and warnings are emitted because `<cstdint>` is not included when `uint32_t` is used and there are some unused variables. This PR includes `<cstdint>` where needed and comments out the unused variables. I have tested the changed on Linux (gcc 13.2.1 x86_64-pc-linux-gnu) and macOS (Apple clang 14.0.3 x86_64-apple-darwin22.5.0) but not Windows. However, I don't think there would be any issues on Windows.

Also, while trying to get this to run on a DD-WRT router (32 MB of RAM), I found a memory leak in the `hexstr_to_intarray` function (in util.cpp). The `malloc`'d string `bytes` returned from `hexstr_to_char` is never freed. Because the function gets called over and over again, it starts to add up. This PR fixes that bug.